### PR TITLE
[HOTFIX] 뉴스 기사 호출 주석 처리

### DIFF
--- a/medihub-fe/src/components/main/NewsSection.vue
+++ b/medihub-fe/src/components/main/NewsSection.vue
@@ -46,7 +46,7 @@ const getNewsArticles = async () => {
   }
 }
 
-onMounted(getNewsArticles);
+//onMounted(getNewsArticles);
 
 // 날짜 포맷팅 함수
 const formatDate = (dateString) => {


### PR DESCRIPTION
close: #87 
## 구현 기능
메인페이지가 로드될 때마다 뉴스 기사 조회가 호출됨 -> 너무 많은 요청으로 NewsApi 요청이 막히는 이슈 발생으로 주석 처리